### PR TITLE
initial pass (which works with ssh config modification) to add web ui

### DIFF
--- a/scripts/consul_server.sh
+++ b/scripts/consul_server.sh
@@ -9,5 +9,12 @@ sudo mkdir -p /etc/consul.d/server
 sudo cp /vagrant/scripts/templates/consul_server_config.json /etc/consul.d/server/config.json
 sudo sed -i'' -e "s/\:ip\:/$ip/" /etc/consul.d/server/config.json
 
+cd /tmp
+sudo mkdir -p /var/lib/consul
+wget --quiet https://dl.bintray.com/mitchellh/consul/0.4.1_web_ui.zip
+unzip 0.4.1_web_ui.zip
+sudo mv dist /var/lib/consul/web_ui
+sudo chown -R vagrant:vagrant /var/lib/consul
+
 sudo foreman export upstart /etc/init --procfile /vagrant/consul/Procfile.consul-server --user vagrant --app consul
 sudo service consul restart

--- a/scripts/templates/consul_server_config.json
+++ b/scripts/templates/consul_server_config.json
@@ -2,6 +2,7 @@
     "server": true,
     "datacenter": "vagrant",
     "data_dir": "/tmp/consul",
+    "web_ui": "/var/lib/consul/web_ui",
     "log_level": "INFO",
     "enable_syslog": true,
     "start_join": [],


### PR DESCRIPTION
This will setup the web ui, using an ssh tunnel. I spent some time trying to get it to work with a standard vagrant setup using "forwarded_port" (e.g. as in the proxy configuration) but consul is doing something funky with a redirect which I didn't have the patience to see through.

My ssh config block for this looks like:

```
Host consul
  Hostname 127.0.0.1
  Port 2222
  User vagrant
  LocalForward 8500 localhost:8500
```
